### PR TITLE
[Day 8] BOJ 1446. 지름길

### DIFF
--- a/gyeoul/BOJ1446.kt
+++ b/gyeoul/BOJ1446.kt
@@ -1,0 +1,30 @@
+import java.util.StringTokenizer
+
+class BOJ1446 {
+    fun main() = with(System.`in`.bufferedReader()) {
+        var st = StringTokenizer(readLine())
+        val n = st.nextToken().toInt()
+        val d = st.nextToken().toInt()
+        val map = IntArray(d + 1) { Int.MAX_VALUE }
+        val loc = Array<MutableList<Pair<Int, Int>>>(d + 1) { mutableListOf() }
+
+        for (i in 0 until n) {
+            st = StringTokenizer(readLine())
+            val a = st.nextToken().toInt()
+            val b = st.nextToken().toInt()
+            val cost = st.nextToken().toInt()
+            if (a !in 0..d || b !in 0..d) continue
+            loc[b].add(Pair(a, cost))
+        }
+        map[0] = 0
+        for (i in 1..d) {
+            if (loc[i].isEmpty()) map[i] = map[i - 1] + 1
+            else {
+                for (v in loc[i]) {
+                    map[i] = map[i].coerceAtMost((map[i - 1] + 1).coerceAtMost(map[v.first] + v.second))
+                }
+            }
+        }
+        print(map[d])
+    }
+}


### PR DESCRIPTION
1. 입력받은 d+1만큼의 배열을 생성하고 각 배열에 뮤터블 리스트를 할당
2. 입력받은 n개의 지름길을 생성한 배열에 기록
3. 0부터 배열을 순회하며 값이 없을 경우 1을 추가하고 배열에 기록
4. 지름길이 존재하는 경우 지름길에 도달할 수 있는 곳에 현재 cost값과 기록된 값 중 작은값을 비교하여 지름길 도착 지점에 기록
5. 값이 존재할 경우 현재의 cost와 기록된 cost를 비교하여 적은쪽을 배열에 기록
6. 최종적으로 목적지까지 모두 순회했을 때 마지막 칸에 적힌 값을 출력