### PR TITLE
[Day 9] BOJ 1149. RGB거리

### DIFF
--- a/gyeoul/BOJ1149.kt
+++ b/gyeoul/BOJ1149.kt
@@ -1,0 +1,100 @@
+import java.util.StringTokenizer
+
+/*
+문제
+RGB거리에는 집이 N개 있다. 거리는 선분으로 나타낼 수 있고, 1번 집부터 N번 집이 순서대로 있다.
+집은 빨강, 초록, 파랑 중 하나의 색으로 칠해야 한다. 각각의 집을 빨강, 초록, 파랑으로 칠하는 비용이 주어졌을 때, 아래 규칙을 만족하면서 모든 집을 칠하는 비용의 최솟값을 구해보자.
+1번 집의 색은 2번 집의 색과 같지 않아야 한다.
+N번 집의 색은 N-1번 집의 색과 같지 않아야 한다.
+i(2 ≤ i ≤ N-1)번 집의 색은 i-1번, i+1번 집의 색과 같지 않아야 한다.
+
+입력
+첫째 줄에 집의 수 N(2 ≤ N ≤ 1,000)이 주어진다. 둘째 줄부터 N개의 줄에는 각 집을 빨강, 초록, 파랑으로 칠하는 비용이 1번 집부터 한 줄에 하나씩 주어진다. 집을 칠하는 비용은 1,000보다 작거나 같은 자연수이다.
+출력
+첫째 줄에 모든 집을 칠하는 비용의 최솟값을 출력한다.
+
+예제 입력 1
+3
+26 40 83
+49 60 57
+13 89 99
+예제 출력 1
+96
+
+예제 입력 2
+3
+1 100 100
+100 1 100
+100 100 1
+예제 출력 2
+3
+
+예제 입력 3
+3
+1 100 100
+100 100 100
+1 100 100
+예제 출력 3
+102
+
+예제 입력 4
+6
+30 19 5
+64 77 64
+15 19 97
+4 71 57
+90 86 84
+93 32 91
+예제 출력 4
+208
+
+예제 입력 5
+8
+71 39 44
+32 83 55
+51 37 63
+89 29 100
+83 58 11
+65 13 15
+47 25 29
+60 66 19
+예제 출력 5
+253
+*/
+class BOJ1149 {
+// 재귀 시도
+//fun search(next: Int, color: Int): Int {
+//    if (next !in 0..n) return 0
+//    repeat(3) {
+//        if (color != it) {
+//            ans = ans.coerceAtMost(search(next + 1, it) + arr[next][it])
+//        }
+//    }
+//    return ans
+//}
+//bw.write("${search(0, 0)}")
+
+    fun main() = with(System.`in`.bufferedReader()) {
+        val bw = System.out.bufferedWriter()
+        val n = readLine().toInt()
+        val arr = Array(n) { Array(3) { 0 } }
+        val ans = Array(n + 1) { Array(3) { 0 } }
+        var st: StringTokenizer
+        repeat(n) { i ->
+            st = StringTokenizer(readLine())
+            repeat(3) { j ->
+                arr[i][j] = st.nextToken().toInt()
+            }
+            repeat(3) { j ->
+                ans[i + 1][j] = when (j) {
+                    0 -> ans[i][1].coerceAtMost(ans[i][2])
+                    1 -> ans[i][0].coerceAtMost(ans[i][2])
+                    2 -> ans[i][0].coerceAtMost(ans[i][1])
+                    else -> 0
+                } + arr[i][j]
+            }
+        }
+        bw.write("${ans[n].min()}")
+        bw.flush()
+    }
+}


### PR DESCRIPTION
재귀 시도 후 DP로 변경
0으로 초기화한 n*3 arr 배열과 dp를 실행할 (n+1)*3 ans 배열을 생성하고
배열을 순회하며 각각의 위치 i 에서 현재 R,G,B 값과 0~(i-1)합의 최소값을 더해
ans 배열에 저장하며 마지막 n+1 인덱스에 저장되는 각각의 값 중 가장 작은 값을 출력했다.