### PR TITLE
[Day 11] BOJ 9465. 스티커

### DIFF
--- a/ybwi0912/BOJ9465.java
+++ b/ybwi0912/BOJ9465.java
@@ -1,0 +1,47 @@
+package ybwi0912;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/*
+ * 2023-08-08
+ * BOJ 9465: 스티커
+ * DP - 점화식을 세워서 해결
+ * */
+
+public class BOJ9465 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(bf.readLine());
+
+        for(int i=0; i<T; i++){
+            int n = Integer.parseInt(bf.readLine());
+
+            int[][] stickers = new int[2][n+1]; // 노드의 이전 노드와 그 이전 노드를 고려하기 위해 n+1으로 크기 설정
+            int[][] dp = new int[2][n+1];
+
+            for(int j=0; j<2; j++){
+                String[] input = bf.readLine().split(" ");
+                // StringTokenizer -> String.split()으로 고치면서 시간은 줄고 메모리는 늘었다
+
+                for(int k=1; k<n+1; k++) stickers[j][k] = Integer.parseInt(input[k-1]);
+            }
+            // input
+
+            dp[0][1] = stickers[0][1];
+            dp[1][1] = stickers[1][1];
+            // 초기값 설정
+
+            for(int j=2; j<n+1; j++){
+                dp[0][j] = Math.max(dp[1][j-1], dp[1][j-2]) + stickers[0][j];
+                dp[1][j] = Math.max(dp[0][j-1], dp[0][j-2]) + stickers[1][j];
+            } // 대각선 방향의 한 칸 앞, 두 칸 앞의 스티커 고려
+            // operation
+
+            System.out.println(Math.max(dp[0][n], dp[1][n]));
+            // 각 열의 마지막 스티커까지 확인한 후 최댓값을 출력
+            // output
+        }
+    }
+}


### PR DESCRIPTION
![KakaoTalk_20230808_232715574](https://github.com/Dream-Waves/CodeSurfing/assets/103356049/b4268b7e-2a17-40e5-a9ae-3d5739acfae8)

<b>DP(점화식)</b> - 각 열의 두 번째 스티커부터 대각선 방향의 한 칸 앞, 두 칸 앞의 스티커 중 점수가 높은 스티커를 선택해 더해나간다. dp 배열 각 열의 마지막 행은 해당 스티커를 선택했을 때 얻을 수 있는 점수의 최댓값이 된다. 두 행 중 최댓값을 찾아 출력.

<hr/>

### ⚠ 
- 입력단에서 StringTokenizer를 String.split()으로 수정하면서 실행 시간은 줄어들고 필요 메모리는 증가했다
- stickers, dp 배열의 크기(n+1) 주의
