### PR TITLE
[Day 24] BOJ 2841. 외계인의 기타 연주

### DIFF
--- a/gyeoul/BOJ2841.kt
+++ b/gyeoul/BOJ2841.kt
@@ -1,0 +1,19 @@
+class BOJ2841 {
+    fun main() {
+        val (n, _) = readln().split(" ").map { it.toInt() } // N, P 입력, 단 P는 사용하지 않아 _ 처리
+        val arr = Array(7) { ArrayDeque<Int>() } //각 줄마다 손가락의 위치를 확인하기 위한 스택 저장
+        var count = 0 // 손가락의 움직임 횟수를 파악하는 변수
+        repeat(n) {
+            val (line, fret) = readln().split(" ").map { it.toInt() } // 라인과 프랫 입력
+            while (arr[line].isNotEmpty() && arr[line].last() > fret) {
+                arr[line].removeLast() // 현재 라인의 입력받은 프랫 뒤에있는 손가락 모두 떼기
+                count++
+            }
+            if (arr[line].isEmpty() || arr[line].last() != fret) { // 이전과 동일한 위치에 손가락이 위치한 경우 건너뜀
+                arr[line].addLast(fret) // 아닐경우 해당 라인의 손가락 위치를 저장
+                count++
+            }
+        }
+        print(count)
+    }
+}

--- a/gyeoul/BOJ2841.kt
+++ b/gyeoul/BOJ2841.kt
@@ -1,7 +1,7 @@
 class BOJ2841 {
     fun main() {
-        val (n, _) = readln().split(" ").map { it.toInt() } // N, P 입력, 단 P는 사용하지 않아 _ 처리
-        val arr = Array(7) { ArrayDeque<Int>() } //각 줄마다 손가락의 위치를 확인하기 위한 스택 저장
+        val (n, p) = readln().split(" ").map { it.toInt() } // N, P 입력
+        val arr = Array(7) { ArrayDeque<Int>(p) } //각 줄마다 손가락의 위치를 확인하기 위한 스택 저장
         var count = 0 // 손가락의 움직임 횟수를 파악하는 변수
         repeat(n) {
             val (line, fret) = readln().split(" ").map { it.toInt() } // 라인과 프랫 입력
@@ -10,7 +10,7 @@ class BOJ2841 {
                 count++
             }
             if (arr[line].isEmpty() || arr[line].last() != fret) { // 이전과 동일한 위치에 손가락이 위치한 경우 건너뜀
-                arr[line].addLast(fret) // 아닐경우 해당 라인의 손가락 위치를 저장
+                arr[line].addLast(fret) // 아닐 경우 해당 라인의 손가락 위치를 저장
                 count++
             }
         }


### PR DESCRIPTION
각 줄마다 프랫을 누른 손가락 위치를 저장하기 위한 스택을 생성하고
각 줄마다 입력받은 줄의 프랫 위치보다 뒤에 위치한 모든 손가락을 떼는 방식으로 손가락의 이동 횟수를 계산하였다

입력받는 도중 -1을 처리하는것보다 ArrayDeque를 담는 줄 배열을 하나 더 늘려 사용하는것이 메모리, 시간면에서 훨씬 효율적 이었기 때문에 조금의 메모리 낭비가 있지만 7칸의 배열을 생성하였다

처음에 입력받은 N, P중 P는 사용하지 않고 ArrayDeque의 동적 할당을 이용하였으나 P값을 활용하여 initialCapacity를 할당해주었을때 `872ms` -> `772ms`로 약 100ms 의 시간이 단축되었다
반면 메모리는 315KB만을 더 사용하는것으로 보아 initialCapacity로 할당할 수 있는 값이 있다면 할당하는것이 코드의 성능에 도움이 될 수 있을것 같다