### PR TITLE
[Day 30] BOJ 17609. 회문

### DIFF
--- a/gyeoul/BOJ17609.kt
+++ b/gyeoul/BOJ17609.kt
@@ -1,0 +1,33 @@
+class BOJ17609 {
+    fun main() {
+        fun check(text: String, a: Int, b: Int): Boolean {
+            return text[a] == text[b] // 입력받은 텍스트가 일치하는지 여부를 반환
+        }
+        repeat(readln().toInt()) {
+            val text = readln() // 검사할 글자
+            var l = -1 // 왼쪽 포인터
+            var r = text.length // 오른쪽 포인터
+            var flag = true // 유사회문일 경우 false
+            var status = true // 두번 이상 일치하지 않을경우 false
+            var left = true // 유사회문일때 방향성 설정
+            var right = true
+            while (++l < --r && status) {
+                if (flag) { // 유사회문이 아닐경우 검사
+                    flag = check(text, l, r) // 유사회문일 경우를 대비하여 flag에 대입
+                }
+                if (!flag) { // 유사회문일 경우 검사
+                    if (left) left = check(text, l + 1, r) // 좌측을 한칸 더 전진시켜 검사
+                    if (right) right = check(text, l, r - 1) // 우측을 한칸 더 전진시켜 검사
+                    if (!left && !right) status = false // 양쪽 모두 검사를 실패한 경우 상태값 변경
+                }
+            }
+            println(
+                when {
+                    !status -> 2 // 검사 실패
+                    !flag -> 1 // 검사 성공 & 유사 회문
+                    else -> 0 // 검사 성공 & 완전 회문
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
투포인터를 활용한 풀이
```kotlin
var left = true
var right = true
// ... 생략
                if (!flag) { 
                    if (left) left = check(text, l + 1, r) 
                    if (right) right = check(text, l, r - 1)
                    if (!left && !right) status = false
                }
```
위처럼 반복문 내에서 유사회문일 때 두개의 불리언 값으로 방향성을 설정해주지 않고
```kotlin
            if (!flag) {
                status = check(l + 1, r) || check(l, r - 1)
            }
```
형식으로 or을 활용하여 status에 대입하는 경우
두번 이상 값이 다른 경우 + 반대쪽을 1개 전진시켰을 경우 일치하는 때에
제대로 status를 잡아내지 못하는 경우가 생겼었다