### PR TITLE
[Day 41] BOJ 2531. 회전 초밥

### DIFF
--- a/ybwi0912/BOJ2531.py
+++ b/ybwi0912/BOJ2531.py
@@ -1,0 +1,28 @@
+N, d, k, c = map(int, input().split())
+# 접시의 수, 초밥의 가짓수, 연속해서 먹는 접시의 개수, 쿠폰 번호
+li = [] # 초밥 벨트의 상태
+
+for i in range(N):
+    li.append(int(input()))
+
+m = 0 # 초밥 가짓수의 최대값
+idx = k-1 # 끝 인덱스
+for i in range(N): # 시작 인덱스 i
+    if idx >= N:
+        idx -= N
+
+    if i < idx:
+        s = li[i:idx+1]
+    else:
+        s = li[i:] + li[:idx+1]
+    # 리스트의 i번째 초밥부터 idx번째 초밥까지 새로운 리스트에 저장
+
+    s = set(s) # 중복되는 요소를 한 번만 포함시키기 위해 세트로 전환
+    s.add(c) # 세트에 쿠폰으로 먹을 수 있는 초밥 추가
+
+    if m < len(s):
+        m = len(s) # 중복된 초밥을 제거한 실제 먹을 수 있는 초밥의 가짓수를 확인해 최대값 갱신
+
+    idx += 1 # 끝 인덱스 +1
+
+print(m)


### PR DESCRIPTION
### 슬라이딩 윈도우 
① 시작 인덱스 i와 k만큼 차이 나는 끝 인덱스 idx를 사용해 i번째 초밥부터 먹었을 때 먹을 수 있는 초밥들의 리스트를 슬라이싱
② 중복되는 번호를 제거하기 위해 리스트를 세트로 변환
③ 세트에 쿠폰 번호를 추가 (이미 쿠폰으로 먹을 수 있는 초밥의 번호가 세트 내에 존재하더라도 세트에는 중복되는 값이 자동으로 한 개만 저장된다)
④ 세트에 들어 있는 초밥의 개수와 최댓값을 비교 후 최댓값 갱신

### ⚠
기존에는 i부터 k번 반복문을 돌면서 세트에 리스트의 i번째 요소를 추가했었는데 매번 k회씩 반복문을 돌다 보니 시간 초과가 발생했다
-> 반복문을 돌 필요 없이 리스트를 슬라이싱하여 사용함으로써 해결 