### PR TITLE
[Day 41] BOJ 2531. 회전 초밥

### DIFF
--- a/gyeoul/BOJ2531.kt
+++ b/gyeoul/BOJ2531.kt
@@ -1,0 +1,25 @@
+class BOJ2531 {
+    fun main() {
+        val (n, d, k, c) = readln().split(" ").map { it.toInt() }
+        val belt = IntArray(n) // 벨트 배열
+        val arr = IntArray(d + 1) // 초밥 가짓수 (접시 수 저장)
+        var ans = 0
+        fun calcMax() { // 1개 이상 먹은 초밥의 가짓수를 계산하는 함수
+            var now = arr.filter { it > 0 }.size // ĸ개 만큼 초밥을 먹었을때 1개 이상 먹은 초밥의 가짓수
+            if (arr[c] < 1) now++ // 쿠폰으로 받은 초밥을 먹지 않았을 경우 먹기
+            ans = Math.max(ans, now) // 초밥 가짓수의 최대값 갱신
+        }
+        repeat(n) {
+            val now = readln().toInt()
+            belt[it] = now // 벨트에 입력받은 초밥 올리기
+            if (it < k) arr[now]++ // 처음부터 k번째까지 먹은 가짓수를 먼저 저장
+        }
+        calcMax() // 가짓수 계산
+        for (i in k until n + k) { // k번째부터 벨트를 한바퀴 돌아 n+k-1만큼 까지 모든 경우의 수를 계산
+            arr[belt[i % n]]++ // k+1번째의 접시를 먹고
+            arr[belt[i - k]]-- // 처음 먹은 접시를 먹지 않은 경우의
+            calcMax() // 가짓수 계산
+        }
+        print(ans) // 최대로 먹을 수 있는 가짓수를 출력
+    }
+}


### PR DESCRIPTION
d+1개의 크기를 가지는 Int 배열을 사용한 슬라이딩 윈도우 방식으로 해결

HashMap을 사용해 저장을 시도했으나 값이 0, null 등 다양한 방식으로 처리해주어야 할 예외가 많아 중도 선회
ArrayDeque를 사용하여 큐에 각각의 접시를 담고 contains 함수를 사용하여 최종 접시 수를 계산하는 방식으로 시도하였으나
큐에 대한 contains 함수 실행 속도의 문제로 시간초과 실패

Int배열에 k개를 먹는 동안 각각의 접시수를 담고
filter를 사용하여 접시가 1개 이상인 초밥의 갯수를 판별
쿠폰으로 받은 초밥을 먹지 않았을 경우엔 추가로 쿠폰 초밥을 더하여 먹을수 있는 최대 가짓수를 계산하였다

0부터n까지의 접시 중 n-3 ~ 3 등이 나올 수 있는 경우를 고려하여 0부터 k까지 저장, k부터 k+n까지 순회하며 계산하는 방식을 사용하였다
