### PR TITLE
[Day 45] BOJ 20364. 부동산 다툼

### DIFF
--- a/gyeoul/BOJ20364.java
+++ b/gyeoul/BOJ20364.java
@@ -1,0 +1,25 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class BOJ20364 {
+    public static void main(String[] args) throws Exception {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(bf.readLine()); // 입력
+        int n = Integer.parseInt(st.nextToken()) + 1; // 땅 개수 0을 사용하지 않으므로 + 1
+        int q = Integer.parseInt(st.nextToken()); // 오리 수
+        boolean[] arr = new boolean[n]; // 땅을 점유했는지 확인할 배열
+        for (int idx = 0; idx < q; idx++) {
+            int raw = Integer.parseInt(bf.readLine()); // 현재 오리가 원하는 땅 번호
+            int ans = 0; // 다른 오리의 땅을 밟을 경우 변경
+            for (int i = raw; i > 1; i /= 2) if (arr[i]) ans = i; // 수식에 따라 raw부터 1까지 탐색
+            arr[raw] = true; // 현재 오리가 원하는 땅을 할당
+            bw.write(ans + "\n"); // 정답 출력
+        }
+        bw.flush();
+        bw.close();
+    }
+}


### PR DESCRIPTION
visited 배열을 활용해 해결

`K * 2` or `K * 2 + 1`의 수식을 따라 각 오리가 원하는 땅에서부터 출발 지점까지 탐색
탐색 중 이전 오리가 받은 땅을 거칠경우 값을 기록

int배열에 도착지를 기록하며 탐색한 경우
57720KB | 2188ms
TreeSet에 도착지를 기록한 경우
88960KB | 1356ms
boolean 배열에 도착지를 기록한 경우
40024KB | 532ms

TreeSet의 이진탐색보다 배열의 인덱스 접근의 속도가 월등히 빠르고 컬렉션이 사용하는 메모리 크기또한 작았다
