### PR TITLE
[Day 52] BOJ 1747. 소수&팰린드롬

### DIFF
--- a/gyeoul/BOJ1747.kt
+++ b/gyeoul/BOJ1747.kt
@@ -1,0 +1,28 @@
+class BOJ1747 {
+    fun main() {
+        fun check(str: String): Boolean { // 팰린드롬(회문) 검사 함수
+            var (l, r) = Pair(0, str.lastIndex) // 인덱스 선언
+            while (l < r) if (str[l++] != str[r--]) return false // 회문 검사
+            return true // 회문인 경우
+        }
+
+        fun calc(min: Int): Int { // 소수 검사 및 결과 계산 함수
+            val num = BooleanArray(1_003_002) // 소수 검사 배열
+            for (i in 2..1_003_001) {
+                if (num[i]) continue // 이전에 계산된 값일 경우 건너뛰기
+                else for (j in i * 2..1_003_001 step i) num[j] = true
+                // 처음 만나는 경우 자신의 배수를 사용 불가능하게 만들기
+            }
+            num.forEachIndexed { idx, v ->
+                if (!v && idx > 1 && idx >= min && check(idx.toString())) return idx
+                // 처음 만나는 소수가 팰린드롬(회문)인 경우 소수 반환
+            }
+            return 0 // 오류 대비 반환값
+        }
+
+        val bw = System.out.bufferedWriter()
+        val n = System.`in`.bufferedReader().readLine().toInt()
+        bw.write("${calc(n)}") // 함수 실행 후 출력
+        bw.flush()
+    }
+}


### PR DESCRIPTION
에라토스테네스의 체를 활용한 풀이

에라토스테네스의 체를 사용할 경우 Int배열보다 Boolean배열을 ### 활용하여 소수 검사를 하는것이 훨씬 빠르며
Int 배열을 Set을 통해 걸러내고 싶을 경우 TreeSet으로 선언하고 관리하는것 보다 스트림을 활용해 toSet, toList로 변환하는 것이 빨랐다
팰린드롬(회문)을 검사하는것 또한 String.reversed를 사용해 비교하는것 보다 L,R 인덱스를 생성해 비교하는것이 메모리, 속도 측면에서 이점이 있었다

