### PR TITLE
[Day 64] BOJ 12865. 평범한 배낭

### DIFF
--- a/Jieun714/BOJ12865.java
+++ b/Jieun714/BOJ12865.java
@@ -1,0 +1,42 @@
+package Jieun714;
+/**
+ * 문제: 이 문제는 아주 평범한 배낭에 관한 문제이다. 한 달 후면 국가의 부름을 받게 되는 준서는 여행을 가려고 한다. 세상과의 단절을 슬퍼하며 최대한 즐기기 위한 여행이기 때문에, 가지고 다닐 배낭 또한 최대한 가치 있게 싸려고 한다.
+ *      준서가 여행에 필요하다고 생각하는 N개의 물건이 있다. 각 물건은 무게 W와 가치 V를 가지는데, 해당 물건을 배낭에 넣어서 가면 준서가 V만큼 즐길 수 있다. 아직 행군을 해본 적이 없는 준서는 최대 K만큼의 무게만을 넣을 수 있는 배낭만 들고 다닐 수 있다.
+ *      준서가 최대한 즐거운 여행을 하기 위해 배낭에 넣을 수 있는 물건들의 가치의 최댓값을 알려주자.
+ * 입력: 첫 줄에 물품의 수 N(1 ≤ N ≤ 100)과 준서가 버틸 수 있는 무게 K(1 ≤ K ≤ 100,000)가 주어진다. 두 번째 줄부터 N개의 줄에 거쳐 각 물건의 무게 W(1 ≤ W ≤ 100,000)와 해당 물건의 가치 V(0 ≤ V ≤ 1,000)가 주어진다.
+ *      입력으로 주어지는 모든 수는 정수이다.
+ * 출력: 한 줄에 배낭에 넣을 수 있는 물건들의 가치합의 최댓값을 출력한다.
+ * 해결: 다이나믹 프로그래밍(냅색 문제)
+ * */
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ12865 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken()); //물품의 수
+        int K = Integer.parseInt(st.nextToken()); //준서가 버틸 수 있는 무게
+
+        int [] W = new int[N+1]; //각 물건의 무게를 담은 배열
+        int [] V = new int[N+1]; //각 물건의 가치를 담은 배열
+        for(int i=1; i<=N; i++){
+            st = new StringTokenizer(br.readLine());
+            W[i] = Integer.parseInt(st.nextToken());
+            V[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[][] dp = new int[N+1][K+1];
+        for(int i=1; i<=N; i++){
+            for(int j=1; j<=K; j++){
+                if(W[i]>j) //i번째 무게를 더이상 담을 수 없다면
+                    dp[i][j] = dp[i-1][j]; //이전과 동일한 가치를 저장
+                else //i번째 무게를 담을 수 있다면
+                    dp[i][j] = Math.max(dp[i-1][j], (dp[i-1][j - W[i]]) + V[i]); //이전 가치와 남은 공간에 가치 추가 후 결과 중 더 큰 가치를 저장
+            }
+        }
+        System.out.println(dp[N][K]); //배낭에 넣을 수 있는 물건들의 가치합의 최댓값 출력
+    }
+}


### PR DESCRIPTION
### Review

**이슈**
dp 배열 설정을 잘못해서, 인덱스 참조의 범위를 벗어나는 이슈가 발생.
배열 설정과 이중 for문을 돌며 수행하는 dp 연산에서 인덱스 값을 수정해서 해결

<br>

**풀이 방식**
'물품의 수X준서가 버틸수 있는 무게'만큼 dp 연산을 수행한다.
만약 i번째 물품의 무게(W[i])가 현재(j) 무게보다 크다면, 이전과 동일한 가치를 dp에 저장하고
그렇지 않다면 이전 가치와 남은 공간(dp[i-1][j-W[i])에 현재가치(V[i])를 추가 후 결과를 비교하여 더 큰 가치를 dp에 저장한다.
<br>

dp 로직을 수행하는 함수

``` java
int[][] dp = new int[N+1][K+1];
for(int i=1; i<=N; i++){
   for(int j=1; j<=K; j++){
        if(W[i]>j) //i번째 무게를 더이상 담을 수 없다면
             dp[i][j] = dp[i-1][j]; //이전과 동일한 가치를 저장
        else //i번째 무게를 담을 수 있다면
             dp[i][j] = Math.max(dp[i-1][j], (dp[i-1][j - W[i]]) + V[i]); //이전 가치와 남은 공간에 가치 추가 후 결과 중 더 큰 가치를 저장
   }
}
```