### PR TITLE
[Day 67] BOJ 1389. 케빈 베이컨의 6단계 법칙

### DIFF
--- a/gyeoul/BOJ1389.kt
+++ b/gyeoul/BOJ1389.kt
@@ -1,0 +1,33 @@
+class BOJ1389 {
+    fun main() = with(System.`in`.bufferedReader()) {
+        val (n, m) = readLine().split(" ").map { it.toInt() }
+        // N, M 입력
+        val user = Array(n) { i -> IntArray(n) { j -> if (i == j) 0 else 10000 } }
+        // 인덱스가 동일한 곳은 0 아닌곳은 큰 숫자로 2차원 배열 생성 및 초기화
+        repeat(m) {
+            val st = java.util.StringTokenizer(readLine())
+            val a = st.nextToken().toInt() - 1 // 유저 번호와 인덱스를 동일하게 하기 위해 - 1로 입력
+            val b = st.nextToken().toInt() - 1
+            user[a][b] = 1 // 친구 사이의 거리를 1로 설정
+            user[b][a] = 1
+        }
+        close() // bufferedReader 입력 닫기
+        val r = 0..<n // 반복적인 범위값 변수
+        for (c in r) { // 경유하는 친구 (중간값)
+            for (s in r) { // 계산할 친구
+                for (e in r) { // 친구 S와 얼마나 떨어져 있는지 계산할 친구
+                    val path = user[s][c] + user[c][e] // 중간값을 경유하는 경로
+                    if (user[s][e] > path) user[s][e] = path // 현재보다 중간을 거쳐가는게 빠를때 값 갱신
+                }
+            }
+        }
+        with(System.out.bufferedWriter()) { // bufferedWriter 포함 코드블럭
+            val process = user.map { it.sum() } // 각 인원마다 케빈베이컨 스코어 합산
+            val min = process.min() // 케빈베이컨 최소값 도출
+            val idx = process.indexOf(min) // 처음 만나는 (가장 작은) 최소값 인원의 인덱스 확인
+            write("${idx + 1}") // 유저번호를 출력해야 하기 때문에 +1
+            flush() // 버퍼 출력
+            close() // bufferedWriter 닫기
+        }
+    }
+}


### PR DESCRIPTION
플로이드 워셜 알고리즘을 활용한 풀이

BFS로 풀이를 시도했으나 방문 및 계산에 필요한 배열들이 늘어나고 오답이 발생해 디버깅의 어려움을 겪을것으로 예상하여 플로이드 워셜 알고리즘으로 변경하여 풀이하였다

친구 A,B,C를 정해
A가 C와 얼마나 떨어져 있는지 계산하는 방식으로 B를 통한 거리가 가까운지 A-C의 직접 거리가 가까운지 계산하여 기록한다
2차원 배열에 기록된 내용을 바탕으로 각각 모든 친구와의 케빈 베이컨 거리를 합산해 최소값을 가진 첫번째 유저를 출력한다