### PR TITLE
[Day 80] BOJ 9935. 문자열 폭발

### DIFF
--- a/gyeoul/BOJ9935.kt
+++ b/gyeoul/BOJ9935.kt
@@ -1,0 +1,17 @@
+class BOJ9935 {
+    fun main() {
+        val br = System.`in`.bufferedReader()
+        val str = br.readLine() // 문자열 입력
+        val del = br.readLine() // 폭발 문자열 입력
+        val sb = StringBuilder() // 정답을 담을 스트링 빌더
+        for (c in str) { // str을 한자씩
+            sb.append(c) // 스트링 빌더에 담기
+            if (sb.endsWith(del)) // 스트링 빌더 끝자리가 폭발 문자열과 일치하면
+                sb.setLength(sb.length - del.length) // 폭발 문자열 자리수만큼 삭제
+        }
+        with(System.out.bufferedWriter()) {
+            write(sb.toString().ifBlank { "FRULA" }) // 조건에 따라 버퍼에 작성
+            flush() // 버퍼 출력
+        }
+    }
+}


### PR DESCRIPTION
입력받은 문자열을 한글자씩 담아 풀이

입력받은 문자열을 한글자씩 스트링 빌더에 담고 스트링 빌더 마지막 문자열과 del 문자열이 일치하는지 확인
일치한다면 스트링 빌더의 자리수를 감소시켜 글자 삭제


`substring`을 활용하여 비교하는 것 보다 `endsWith` 메서드를 활용하는것이 비교 연산에 훨씬 유리하다
추가적으로 `StringBuilder`의 `delete` 메서드는 내부 구현에서 `System.arraycopy`를 활용하므로 `Array.fill`을 활용하는 setLength보다 메모리 사용량이 많다
```kotlin
// Before
// substring 비교 & delete 메서드 사용
// 메모리 124512 KB
val len = str.length - del.length
if (len >= 0 && str.substring(len) == del) {
    str.delete(len, len + del.length)
}
```
```kotlin
// After
// endsWith 메서드 비교 & setLength 메서드 사용
// 메모리 34792 KB
if (sb.endsWith(del)) sb.setLength(sb.length - del.length)
```