### PR TITLE
[Day 96] BOJ 2023. 신기한 소수

### DIFF
--- a/gyeoul/BOJ2023.kt
+++ b/gyeoul/BOJ2023.kt
@@ -1,0 +1,29 @@
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+class BOJ2023 {
+    private fun checkNumber(n: Int): Boolean { // 소수 판별 함수
+        if (n < 2) return false // 0,1 리턴
+        for (i in 2..(sqrt(n.toDouble()).toInt())) {
+            if (n % i == 0) {
+                return false // 소수가 아닌 수는 리턴
+            }
+        }
+        return true // n = 소수
+    }
+
+
+    fun main() {
+        val n = readln().toInt()
+        val bw = System.out.bufferedWriter()
+        val m = 10.0.pow(n).toInt() // 최대 값
+        for (i in m / 10..<m) {
+            tailrec fun check(k: Int, len: Int = m / 10) { // 꼬리재귀 최적화
+                if (len <= 0) bw.write("$i\n") // 끝자리까지 모두 검사했다면 출력
+                else if (checkNumber(k / len)) check(k, len / 10) // 소수인경우 다음 자리수를 포함해 계산
+            }
+            check(i) // 재귀호출
+        }
+        bw.let { it.flush();it.close(); }
+    }
+}


### PR DESCRIPTION
for문을 이용한 소수 판단으로 풀이

에라토스테네스의 체를 사용하게 되면 최대 8자리를 가지는 수까지 계산하고 저장해야 되기 때문에 시간적, 공간적 손실이 많이 발생하게 된다.