### PR TITLE
[Day 109] BOJ 3107. IPv6

### DIFF
--- a/gyeoul/BOJ3107.kt
+++ b/gyeoul/BOJ3107.kt
@@ -1,0 +1,16 @@
+class BOJ3107 {
+    fun main() = with(System.`in`.bufferedReader()) {
+        val raw = readLine() // IP 입력
+        val str = raw.indexOf("::").let { // IP 가 ::를 포함하는 경우
+            if (it < 0) raw // 없으면 그대로
+            else raw.replace("::", "".padStart(9 - raw.count(':'::equals), ':'))
+            // 있다면 : 의 총 개수가 7 개가 되도록 ::를 :::: 처럼 늘려줌
+        }
+        with(System.out.bufferedWriter()) {
+            write(str.split(':').joinToString(":") { it.padStart(4, '0') })
+            // IP 를 : 기준으로 쪼개어 4 자리보다 부족하다면 앞에 0 을 4 자리가 될때까지 더하고 다시 : 를 포함하여 문자열 결합 후 출력
+            flush() // 버퍼 출력
+        }
+    }
+}
+


### PR DESCRIPTION
구현으로 풀이

: 의 개수가 7개가 되도록 ::가 있는경우 :::, :::: 처럼 개수를 늘려 7개를 맞춰둔 뒤
각 : 으로 문자열을 분해한 뒤 각각의 문자열을 4자리로 맞추어 출력하였다

이 출력문 대신
```kotlin
            write(str.split(':').joinToString(":") { it.padStart(4, '0') })
```
이렇게 사용한다면 joinToString의 성능저하 없이 같은 결과를 출력해낼 수 있다
```kotlin
            str.split(':').forEachIndexed { i, it ->
                if (i != 0) write(":")
                write(it.padStart(4, '0'))
            }
```