### PR TITLE
[Day 165] BOJ 1967. 트리의 지름

### DIFF
--- a/gyeoul/BOJ1967.kt
+++ b/gyeoul/BOJ1967.kt
@@ -1,0 +1,64 @@
+class BOJ1967 {
+    /*
+    트리의 지름
+
+    문제
+    트리(tree)는 사이클이 없는 무방향 그래프이다.
+    트리에서는 어떤 두 노드를 선택해도 둘 사이에 경로가 항상 하나만 존재하게 된다.
+    트리에서 어떤 두 노드를 선택해서 양쪽으로 쫙 당길 때, 가장 길게 늘어나는 경우가 있을 것이다.
+    이럴 때 트리의 모든 노드들은 이 두 노드를 지름의 끝 점으로 하는 원 안에 들어가게 된다.
+    이런 두 노드 사이의 경로의 길이를 트리의 지름이라고 한다.
+    정확히 정의하자면 트리에 존재하는 모든 경로들 중에서 가장 긴 것의 길이를 말한다.
+    입력으로 루트가 있는 트리를 가중치가 있는 간선들로 줄 때, 트리의 지름을 구해서 출력하는 프로그램을 작성하시오.
+    아래와 같은 트리가 주어진다면 트리의 지름은 45가 된다.
+    트리의 노드는 1부터 n까지 번호가 매겨져 있다.
+
+    입력
+    파일의 첫 번째 줄은 노드의 개수 n(1 ≤ n ≤ 10,000)이다.
+    둘째 줄부터 n-1개의 줄에 각 간선에 대한 정보가 들어온다.
+    간선에 대한 정보는 세 개의 정수로 이루어져 있다.
+    첫 번째 정수는 간선이 연결하는 두 노드 중 부모 노드의 번호를 나타내고, 두 번째 정수는 자식 노드를, 세 번째 정수는 간선의 가중치를 나타낸다.
+    간선에 대한 정보는 부모 노드의 번호가 작은 것이 먼저 입력되고, 부모 노드의 번호가 같으면 자식 노드의 번호가 작은 것이 먼저 입력된다.
+    루트 노드의 번호는 항상 1이라고 가정하며, 간선의 가중치는 100보다 크지 않은 양의 정수이다.
+
+    출력
+    첫째 줄에 트리의 지름을 출력한다.
+     */
+    fun main() {
+        val list = System.`in`.bufferedReader().use { br ->
+            val n = br.readLine().toInt()
+            val list = List(n) { mutableListOf<Pair<Int, Int>>() } // 리스트 생성
+            repeat(n - 1) {
+                val (p, c, v) = br.readLine().split(" ").map { it.toInt() }
+                list[p - 1].add(c - 1 to v)
+                list[c - 1].add(p - 1 to v)
+            }
+            list // 리스트 반환
+        }
+
+        val visit = BooleanArray(list.size)
+        val dist = IntArray(list.size) // 거리 저장
+        fun dfs(s: Int, m: Int = 0) { // s부터 방문하며 다음 노드까지의 가중치를 dist에 저장
+            for ((n, v) in list[s]) {
+                if (!visit[n]) {
+                    visit[n] = true
+                    dist[n] = m + v
+                    dfs(n, m + v)
+                }
+            }
+        }
+
+        visit[0] = true
+        dfs(0) // 루트노드에서 시작
+        val idx = dist.indexOf(dist.max()) // 최대거리 인덱스 저장
+        dist.fill(0) // 거리 배열 초기화
+        visit.fill(false) // 방문 배열 초기화
+        visit[idx] = true // 현재노드로 돌아오지 않도록 설정 **
+        dfs(idx) // 최대거리에서 가장 먼곳 탐색
+
+        System.out.bufferedWriter().use {
+            it.write("${dist.max()}") // 루트 -> 가장 먼 곳 -> 가장 먼 곳 = 지름
+            it.flush()
+        }
+    }
+}


### PR DESCRIPTION
DFS로 풀이

가장 먼 노드 = 가중치의 합이 가장 큰 경우
루트노드에서 가장 먼 노드를 DFS로 찾고
해당 노드에서 다시한번 가장 먼 노드를 DFS를 찾으면 해당 트리에서 가장 긴 경로가 된다
따라서 지름은 가장 먼 노드 + 가장 먼 노드가 되게 된다