### PR TITLE
[Day 182] PRO 92342. 양궁대회

### DIFF
--- a/Jieun714/PRO92342.java
+++ b/Jieun714/PRO92342.java
@@ -1,0 +1,73 @@
+package Jieun714;
+/**
+ * 문제: 카카오배 양궁대회가 열렸습니다.
+ *      라이언은 저번 카카오배 양궁대회 우승자이고 이번 대회에도 결승전까지 올라왔습니다. 결승전 상대는 어피치입니다.
+ *      카카오배 양궁대회 운영위원회는 한 선수의 연속 우승보다는 다양한 선수들이 양궁대회에서 우승하기를 원합니다. 따라서, 양궁대회 운영위원회는 결승전 규칙을 전 대회 우승자인 라이언에게 불리하게 다음과 같이 정했습니다.
+ *
+ *      1. 어피치가 화살 n발을 다 쏜 후에 라이언이 화살 n발을 쏩니다.
+ *      2. 점수를 계산합니다.
+ *        2-1. 과녁판은 아래 사진처럼 생겼으며 가장 작은 원의 과녁 점수는 10점이고 가장 큰 원의 바깥쪽은 과녁 점수가 0점입니다.
+ *        2-2. 만약, k(k는 1~10사이의 자연수)점을 어피치가 a발을 맞혔고 라이언이 b발을 맞혔을 경우 더 많은 화살을 k점에 맞힌 선수가 k 점을 가져갑니다. 단, a = b일 경우는 어피치가 k점을 가져갑니다.
+ *             k점을 여러 발 맞혀도 k점 보다 많은 점수를 가져가는 게 아니고 k점만 가져가는 것을 유의하세요. 또한 a = b = 0 인 경우, 즉, 라이언과 어피치 모두 k점에 단 하나의 화살도 맞히지 못한 경우는 어느 누구도 k점을 가져가지 않습니다.
+ *            - 예를 들어, 어피치가 10점을 2발 맞혔고 라이언도 10점을 2발 맞혔을 경우 어피치가 10점을 가져갑니다.
+ *            - 다른 예로, 어피치가 10점을 0발 맞혔고 라이언이 10점을 2발 맞혔을 경우 라이언이 10점을 가져갑니다.
+ *        2-3. 모든 과녁 점수에 대하여 각 선수의 최종 점수를 계산합니다.
+ *      3. 최종 점수가 더 높은 선수를 우승자로 결정합니다. 단, 최종 점수가 같을 경우 어피치를 우승자로 결정합니다.
+ *      현재 상황은 어피치가 화살 n발을 다 쏜 후이고 라이언이 화살을 쏠 차례입니다.
+ *      라이언은 어피치를 가장 큰 점수 차이로 이기기 위해서 n발의 화살을 어떤 과녁 점수에 맞혀야 하는지를 구하려고 합니다.
+ *      화살의 개수를 담은 자연수 n, 어피치가 맞힌 과녁 점수의 개수를 10점부터 0점까지 순서대로 담은 정수 배열 info가 매개변수로 주어집니다. 이때, 라이언이 가장 큰 점수 차이로 우승하기 위해 n발의 화살을 어떤 과녁 점수에 맞혀야 하는지를
+ *      10점부터 0점까지 순서대로 정수 배열에 담아 return 하도록 solution 함수를 완성해 주세요. 만약, 라이언이 우승할 수 없는 경우(무조건 지거나 비기는 경우)는 [-1]을 return 해주세요.
+ * 해결: 백트래킹
+ * */
+public class PRO92342 {
+    class Solution {
+        public int [] answer = new int[11];
+        public int [] ryan = new int[11];
+        public int max = 0;
+
+        public void backtracking(int n, int [] apeach, int count, int start){
+            if(count == n){
+                int apeach_score = 0; //어피치 최종 점수
+                int ryan_score = 0; //라이언 최종 점수
+
+                for(int i = 0; i < 11; i++){
+                    if(ryan[i] == 0 && apeach[i] == 0) continue;
+                    //라이언이 더 많이 맞췄으면 라이언 점수 증가, 반대라면 어피치 점수 증가
+                    if(ryan[i] > apeach[i]) ryan_score += (10 - i);
+                    else apeach_score += (10 - i);
+                }
+
+                int diff = ryan_score - apeach_score;
+                if(diff > max) { //라이언이 최대의 점수차로 이기는 경우
+                    max = ryan_score - apeach_score;
+                    answer = ryan.clone();
+                } else if(diff == max){ //점수차가 최대 점수차와 같은 경우
+                    for(int i = 10; i > -1 ; i--){
+                        //현재 라이언 배열이 더 낮은 점수를 많이 맞힌 경우, 정답 배열 갱신
+                        if(answer[i] < ryan[i]){
+                            answer = ryan.clone();
+                            break;
+                        }
+
+                        //현재 정답 배열이 더 낮은 점수를 많이 맞힌 경우
+                        if(answer[i] > ryan[i]) break;
+                    }
+                }
+                return;
+            }
+
+
+            for(int i = start; i<11; i++){
+                if(apeach[i] < ryan[i]) continue;
+                ryan[i]++;
+                backtracking(n, apeach, count+1, i);
+                ryan[i]--;
+            }
+        }
+
+        public int[] solution(int n, int[] info) {
+            backtracking(n, info, 0, 0);
+            return max == 0 ? new int[] {-1} : answer; //라이언이 우승할 방법이 없는 경우, -1 리턴
+        }
+    }
+}


### PR DESCRIPTION
### Review

백트래킹 문제

<br> 

해당 문제에서 주의해야할 점은 다음 2가지다.
1. k점(1~10점)을 여러 번을 맞추더라도 k점만 획득한다
2. 어피치와 라이언이 동일한 개수를 맞춘다면 어피치만 점수를 가져간다

<br>

**[문제 풀이]**
- 백트래킹으로 현재 화살을 어디에 쏠지 선택하고, 모든 조합을 탐색
   - 모든 경우의 수를 탐색하면서, 가장 점수 차이가 큰 경우를 저장
   - 만약 점수가 동일하다면, 가장 낮은 점수를 더 많이 맞힌 경우를 저장 
- 화살을 다 쐈다면,  점수를 계산하고 max(가장 큰 점수 차이)보다 크면 answer를 업데이트

<br>

**[로직 설명]**

**backtracking 함수**
```java
void backtracking(int n, int[] apeach, int count, int start) {...}
```
- n: 총 화살 수
- apeach: 어피치가 각 점수에 쏜 화살 수
- count: 현재까지 쏜 화살 수
- start: 현재 어떤 점수 위치부터 화살을 쏠지 결정 (중복 허용)

<br>

**점수 계산**
```java
for (int i = 0; i < 11; i++) {
    if (ryan[i] == 0 && apeach[i] == 0) continue;
    if (ryan[i] > apeach[i]) ryan_score += (10 - i);
    else apeach_score += (10 - i);
}
```
- ryan[i] > apeach[i]: 라이언이 해당 점수 차지
- apeach[i] >= ryan[i]: 어피치가 해당 점수 차지

<br>

**정답 배열 갱신 조건**
```java
if (diff > max) {
    max = diff;
    answer = ryan.clone();
} else if (diff == max) {
    // 낮은 점수부터 비교해서, 더 많이 쏜 배열을 선택
}
```